### PR TITLE
Fix memory leak when binding table data manager

### DIFF
--- a/Presentables/Classes/Protocols/PresentableManager.swift
+++ b/Presentables/Classes/Protocols/PresentableManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-public protocol PresentableManager {
+public protocol PresentableManager: class {
     
     var bindableData: Observable<PresentableSections> { get }
     var data: PresentableSections { get set }

--- a/Presentables/Classes/Table views/Presentables+UITableView.swift
+++ b/Presentables/Classes/Table views/Presentables+UITableView.swift
@@ -28,12 +28,15 @@ extension UITableView: PresentableCollectionElement {
     
     public func bind(withPresentableManager manager: inout PresentableManager) {
         let m = manager
-        manager.bindableData.bind(listener: { (data) in
-            for section: PresentableSection in m.data {
-                self.register(section: section)
+        manager.bindableData.bind { [weak m] (data) in
+            if let data = m?.data {
+                for section: PresentableSection in data {
+                    self.register(section: section)
+                }
             }
+            
             self.safeReloadData()
-        })
+        }
         
         register(presentableSections: &manager.data)
         


### PR DESCRIPTION
Binding a table data manger to a table view was causing a retain cycle where table data managers are never deallocated.  